### PR TITLE
Add commands for exporting hg branches and tags

### DIFF
--- a/book/09-git-and-other-scms/sections/import-hg.asc
+++ b/book/09-git-and-other-scms/sections/import-hg.asc
@@ -113,6 +113,14 @@ $ git shortlog -sn
    365  Joe Smith
 ----
 
+If errors are generated when running the fast-export tool you may need to create mappings files for branches and tags.
+To export Mercurial branches and tags:
+[source,console]
+----
+$ hg branches -c -T"{branch}\n" > ../branches
+$ hg tags -T"{tag}\n" > ../tags
+----
+
 That's pretty much all there is to it.
 All of the Mercurial tags have been converted to Git tags, and Mercurial branches and bookmarks have been converted to Git branches.
 Now you're ready to push the repository up to its new server-side home:


### PR DESCRIPTION
To help users unfamiliar with hg that need to port to git, having commands helps reduce the cognitive load of a migration effort.